### PR TITLE
Vastly improves performance when dealing with large data sets

### DIFF
--- a/KEZCollectionViewTableLayout.podspec
+++ b/KEZCollectionViewTableLayout.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'KEZCollectionViewTableLayout'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.license = 'MIT'
   s.summary = 'A UICollectionViewLayout subclass that handles displaying tabular data, such as something you\'d see in a spreadsheet.'
   s.homepage = 'https://github.com/ketzusaka/KEZCollectionViewTableLayout'
   s.author = { 'James Richard' => 'ketzu@icloud.com' }
-  s.source = { :git => 'https://github.com/ketzusaka/KEZCollectionViewTableLayout.git', :tag => "v1.0.1" }
+  s.source = { :git => 'https://github.com/ketzusaka/KEZCollectionViewTableLayout.git', :tag => "v1.0.2" }
   s.source_files = 'Sources'
   s.ios.deployment_target = '7.0'
 end


### PR DESCRIPTION
There were a few issues with the cell attributes regarding performance when there were a large number of cells (~ > 4000).
1. When building cell attributes during the prepareLayout, we were copying the dictionary. This was slowing it down significantly. 
2. Setting objects to the cellAttributes dictionary was taking a really long time due to comparisons with the other keys. I'm not sure why the dictionary was doing that so often. I figured hashes would be unique for each index path, and thus prevent comparing the buckets, but that appears not to be the case. To prevent this, we are now using multi-dimentional arrays to store the attributes instead of a dictionary. This also resolves problem 1 as we are not copying the array either.
3. Scrolling was incredibly slow. prepareLayout was getting called, which in turn was calling buildCollectionViewContentSize repeatedly. This was going incredibly slow because of the dictionary lookup. It was also calling isEqual: on a lot of NSIndexPath objects. This problem would of been mitigated a lot by removing the dictionary as we did in problem 2, but to improve things further we are no longer rebuilding the content size during a bounds change. It will now only get rebuilt during a explicit invalidation of the layout.
